### PR TITLE
Fix bug in deposit w/ adding `startExitFromDeposit`

### DIFF
--- a/tests/test_two_party_direct_channel.py
+++ b/tests/test_two_party_direct_channel.py
@@ -4,6 +4,10 @@ import os.path
 
 import subprocess
 
+from eth_account.messages import (
+    defunct_hash_message,
+)
+
 import eth_tester
 from eth_tester.exceptions import (
     TransactionFailed,
@@ -12,7 +16,6 @@ from eth_tester.exceptions import (
 from web3 import (
     Web3,
 )
-from web3.contract import ConciseContract
 from web3.providers.eth_tester import (
     EthereumTesterProvider,
 )
@@ -54,13 +57,19 @@ def accounts(tester):
 
 
 @pytest.fixture
+def privkeys(tester):
+    return tester.backend.account_keys
+
+
+
+@pytest.fixture
 def deployed_contract(contract_info, w3, accounts):
     abi, bytecode = contract_info
     C = w3.eth.contract(
         abi=abi,
         bytecode=bytecode,
     )
-    tx_hash = C.constructor([accounts[0], accounts[1]]).transact()
+    tx_hash = C.constructor([accounts[0], accounts[1]], 80640).transact()
     tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
     return w3.eth.contract(
         address=tx_receipt.contractAddress,
@@ -98,3 +107,12 @@ def test_fallback(w3, deployed_contract):
         deployed_contract.fallback.call({
             'from': w3.eth.accounts[1]
         })
+
+
+def test_signing(w3, deployed_contract, privkeys, accounts):
+    message_hash = b'\x12' * 32
+    signed_message = w3.eth.account.signHash(message_hash, privkeys[0])
+    assert message_hash == signed_message['messageHash']
+    v, r, s = tuple(map(signed_message.get, ('v', 'r', 's')))
+    account = w3.eth.account.recoverHash(message_hash, vrs=(v, r, s))
+    assert account == accounts[0]


### PR DESCRIPTION
Thanks for @IIIIllllIIIIllllIIIIllllIIIIllllIIIIll pointing out, the original design locks the funds from both sides after depositing through the fallback. This PR adds `startExitFromDeposit` to fix it.

Besides,
- Add `test_signing` to confirm how to sign.
- Change `80640` to `finalizePeriod`, to make testing easier.