### PR TITLE
[DO NOT MERGE] Error when running the contract

### DIFF
--- a/tests/test_two_party_direct_channel.py
+++ b/tests/test_two_party_direct_channel.py
@@ -61,7 +61,6 @@ def privkeys(tester):
     return tester.backend.account_keys
 
 
-
 @pytest.fixture
 def deployed_contract(contract_info, w3, accounts):
     abi, bytecode = contract_info
@@ -69,7 +68,9 @@ def deployed_contract(contract_info, w3, accounts):
         abi=abi,
         bytecode=bytecode,
     )
-    tx_hash = C.constructor([accounts[0], accounts[1]], 80640).transact()
+    print(f"!@# {w3.eth.blockNumber}")
+    tx_hash = C.constructor([accounts[0], accounts[1]], 10).transact()
+    print(f"!@# {w3.eth.blockNumber}")
     tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
     return w3.eth.contract(
         address=tx_receipt.contractAddress,
@@ -107,6 +108,20 @@ def test_fallback(w3, deployed_contract):
         deployed_contract.fallback.call({
             'from': w3.eth.accounts[1]
         })
+
+
+def test_set_state(w3, tester, deployed_contract, accounts):
+    # deployed_contract.functions.testState({
+    #     "balances": (1, 2),
+    #     "version": 2,
+    # }).call()
+    print(f"!@# {w3.eth.blockNumber}")
+    tester.mine_blocks(num_blocks=1)
+    print(f"!@# {w3.eth.blockNumber}")
+    deployed_contract.functions.getB().call({
+        "from": w3.eth.accounts[1],
+    })
+    pass
 
 
 def test_signing(w3, deployed_contract, privkeys, accounts):

--- a/virtual_channels/contracts/TwoPartyDirectChannel.sol
+++ b/virtual_channels/contracts/TwoPartyDirectChannel.sol
@@ -21,11 +21,22 @@ contract TwoPartyDirectChannel {
   bool[2] hasDeposited;
   uint256 finalizePeriod;
 
+  uint256 b;
+
   constructor (
     address payable[2] memory _participants, uint256 _finalizePeriod
   ) public {
     participants = _participants;
     finalizePeriod = _finalizePeriod;
+    b = 1;
+  }
+
+  // function testState(uint256 a) public {
+  //   b = a;
+  // }
+
+  function getB() public view returns (uint256) {
+    return b;
   }
 
   function setState (


### PR DESCRIPTION
With this branch and run
```bash
$ pytest -s tests/test_two_party_direct_channel.py::test_set_state
```
An error occurs
```bash
self = <eth.vm.logic.invalid.InvalidOpcode object at 0x1101d17f0>
computation = <eth.vm.forks.byzantium.computation.ByzantiumComputation object at 0x1101d13c8>

    def __call__(self, computation):
        raise InvalidInstruction("Invalid opcode 0x{0:x} @ {1}".format(
            self.value,
>           computation.code.pc - 1,
        ))
E       eth.exceptions.InvalidInstruction: Invalid opcode 0x1c @ 18
```

### Refs
- https://ethereum.stackexchange.com/questions/69530/invalid-opcode-0x1c-during-smart-contract-method-execution
- https://ethereum.stackexchange.com/questions/69866/solc-error-invalid-opcode-but-works-in-truffle