### PR TITLE
Add tests for each function

### DIFF
--- a/tests/test_two_party_direct_channel.py
+++ b/tests/test_two_party_direct_channel.py
@@ -62,13 +62,18 @@ def privkeys(tester):
 
 
 @pytest.fixture
-def deployed_contract(contract_info, w3, accounts):
+def finalizePeriod():
+    return 10
+
+
+@pytest.fixture
+def deployed_contract(contract_info, w3, accounts, finalizePeriod):
     abi, bytecode = contract_info
     C = w3.eth.contract(
         abi=abi,
         bytecode=bytecode,
     )
-    tx_hash = C.constructor([accounts[0], accounts[1]], 10).transact()
+    tx_hash = C.constructor([accounts[0], accounts[1]], finalizePeriod).transact()
     tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
     return w3.eth.contract(
         address=tx_receipt.contractAddress,
@@ -108,7 +113,7 @@ def test_fallback(w3, deployed_contract):
         })
 
 
-def test_startExitFromDeposit(w3, tester, deployed_contract, accounts):
+def test_startExitFromDeposit(w3, tester, deployed_contract, finalizePeriod):
     # Test: `startExitFromDeposit` should be called only both deposits are done.
     with pytest.raises(TransactionFailed):
         deployed_contract.functions.startExitFromDeposit().call({
@@ -141,13 +146,128 @@ def test_startExitFromDeposit(w3, tester, deployed_contract, accounts):
     deployed_contract.functions.startExitFromDeposit().transact({
         'from': w3.eth.accounts[0],
     })
-    assert 0 != deployed_contract.functions.finalizesAt().call()
+    assert deployed_contract.functions.finalizesAt().call() == w3.eth.blockNumber + finalizePeriod
 
 
-def test_signing(w3, deployed_contract, privkeys, accounts):
-    message_hash = b'\x12' * 32
-    signed_message = w3.eth.account.signHash(message_hash, privkeys[0])
+def test_finalize(w3, tester, deployed_contract, finalizePeriod):
+    # Test: if `finalizesAt` hasn't been set, the call should fail.
+    with pytest.raises(TransactionFailed):
+        deployed_contract.functions.finalize().call()
+    # Test: after setting `finalizesAt` and `finalizesAt` blocks mined, the call should succeed.
+    deployed_contract.fallback.transact({
+        'from': w3.eth.accounts[0]
+    })
+    deployed_contract.fallback.transact({
+        'from': w3.eth.accounts[1]
+    })
+    deployed_contract.functions.startExitFromDeposit().transact({
+        'from': w3.eth.accounts[0],
+    })
+    tester.mine_blocks(finalizePeriod + 1)
+    deployed_contract.functions.finalize().call()
+
+
+def _int_to_big_endian(a):
+    return a.to_bytes(32, 'big')
+
+
+def _sign_message_hash(w3, message_hash, privkey):
+    signed_message = w3.eth.account.signHash(message_hash, privkey)
     assert message_hash == signed_message['messageHash']
     v, r, s = tuple(map(signed_message.get, ('v', 'r', 's')))
-    account = w3.eth.account.recoverHash(message_hash, vrs=(v, r, s))
-    assert account == accounts[0]
+    return v, _int_to_big_endian(r), _int_to_big_endian(s)
+
+
+def _make_state_digest(w3, balances, version):
+    return w3.soliditySha3(
+        ['uint256[2]', 'uint256'],  # 'uint8', 'bytes32', 'bytes32'],
+        [balances, version],  # 4, b"\x55" * 32, b"\x66" * 32],
+    )
+
+
+def _call_setStateWithoutStruct(w3, deployed_contract, balances, version, sigs):
+    deployed_contract.functions.setStateWithoutStruct(
+        balances,
+        version,
+        sigs[0][0],
+        sigs[0][1],
+        sigs[0][2],
+        sigs[1][0],
+        sigs[1][1],
+        sigs[1][2],
+    ).call({
+        'from': w3.eth.accounts[1],
+    })
+
+
+def test_setStateWithoutStruct(w3, tester, deployed_contract, privkeys, finalizePeriod):
+    balances = [10, 5]
+    version = 1
+    digest = _make_state_digest(w3, balances, version)
+    sigs = [
+        _sign_message_hash(w3, digest, privkeys[0]),
+        _sign_message_hash(w3, digest, privkeys[1]),
+    ]
+
+    # Test: `setState` without full deposits from both side
+    with pytest.raises(TransactionFailed):
+        _call_setStateWithoutStruct(w3, deployed_contract, balances, version, sigs)
+    # deposit 0
+    deployed_contract.fallback.transact({
+        'from': w3.eth.accounts[0],
+        'value': balances[0],
+    })
+    # the call fails
+    with pytest.raises(TransactionFailed):
+        _call_setStateWithoutStruct(w3, deployed_contract, balances, version, sigs)
+    # deposit 1
+    deployed_contract.fallback.transact({
+        'from': w3.eth.accounts[1],
+        'value': balances[1],
+    })
+    # the call succeeds
+    _call_setStateWithoutStruct(w3, deployed_contract, balances, version, sigs)
+
+    # Test: `version` is not larger than the latest one, then fails.
+    with pytest.raises(TransactionFailed):
+        _call_setStateWithoutStruct(w3, deployed_contract, balances, 0, sigs)
+
+    # Test: wrong signatures
+    sigs_copied = sigs.copy()
+    # `v` set to 5
+    sigs_copied[0] = (5, sigs_copied[0][1], sigs_copied[0][2])
+    with pytest.raises(TransactionFailed):
+        _call_setStateWithoutStruct(w3, deployed_contract, balances, version, sigs_copied)
+
+    # Test: fails to call it when the contract has finalized.
+    assert 0 == deployed_contract.functions.finalizesAt().call()
+    deployed_contract.functions.startExitFromDeposit().transact({
+        "from": w3.eth.accounts[0],
+    })
+    assert 0 != deployed_contract.functions.finalizesAt().call()
+    tester.mine_blocks(finalizePeriod + 10)
+    deployed_contract.functions.finalize().transact()
+    with pytest.raises(TransactionFailed):
+        _call_setStateWithoutStruct(w3, deployed_contract, balances, version, sigs)
+
+
+# def test_makeDigest(w3, deployed_contract):
+#     balances = [1, 2]
+#     version = 3
+#     result_solidity = deployed_contract.functions.makeDigest(
+#         balances, version
+#     ).call()
+#     result_w3 = _make_state_digest(w3, balances, version)
+#     assert result_solidity == result_w3
+
+
+# def test_recoverSignerWithoutStruct(w3, deployed_contract, privkeys, accounts):
+#     digest = w3.soliditySha3(
+#         ['bytes32', 'uint8', 'bytes32', 'bytes32'],
+#         [b'\x11' * 32, 2, b'\x33' * 32, b'\x44' * 32],
+#     )
+#     v, r, s = _sign_message_hash(w3, digest, privkeys[0])
+#     addr = deployed_contract.functions.recoverSignerWithoutStruct(
+#         digest, v, r, s
+#     ).call()
+#     assert addr == accounts[0]

--- a/tests/test_two_party_direct_channel.py
+++ b/tests/test_two_party_direct_channel.py
@@ -61,7 +61,6 @@ def privkeys(tester):
     return tester.backend.account_keys
 
 
-
 @pytest.fixture
 def deployed_contract(contract_info, w3, accounts):
     abi, bytecode = contract_info
@@ -69,7 +68,9 @@ def deployed_contract(contract_info, w3, accounts):
         abi=abi,
         bytecode=bytecode,
     )
-    tx_hash = C.constructor([accounts[0], accounts[1]], 80640).transact()
+    print(f"!@# {w3.eth.blockNumber}")
+    tx_hash = C.constructor([accounts[0], accounts[1]], 10).transact()
+    print(f"!@# {w3.eth.blockNumber}")
     tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
     return w3.eth.contract(
         address=tx_receipt.contractAddress,
@@ -107,6 +108,20 @@ def test_fallback(w3, deployed_contract):
         deployed_contract.fallback.call({
             'from': w3.eth.accounts[1]
         })
+
+
+def test_set_state(w3, tester, deployed_contract, accounts):
+    # deployed_contract.functions.testState({
+    #     "balances": (1, 2),
+    #     "version": 2,
+    # }).call()
+    print(f"!@# {w3.eth.blockNumber}")
+    tester.mine_blocks(num_blocks=1)
+    print(f"!@# {w3.eth.blockNumber}")
+    deployed_contract.functions.getB().call({
+        "from": w3.eth.accounts[1],
+    })
+    pass
 
 
 def test_signing(w3, deployed_contract, privkeys, accounts):

--- a/virtual_channels/contracts/TwoPartyDirectChannel.sol
+++ b/virtual_channels/contracts/TwoPartyDirectChannel.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.9;
+pragma solidity ^0.5.0;
 pragma experimental "ABIEncoderV2";
 
 contract TwoPartyDirectChannel {
@@ -15,28 +15,17 @@ contract TwoPartyDirectChannel {
   }
 
   address payable[2] participants;
-  uint256 finalizesAt;
+  uint256 public finalizesAt;
   State latestState;
 
   bool[2] hasDeposited;
   uint256 finalizePeriod;
-
-  uint256 b;
 
   constructor (
     address payable[2] memory _participants, uint256 _finalizePeriod
   ) public {
     participants = _participants;
     finalizePeriod = _finalizePeriod;
-    b = 1;
-  }
-
-  // function testState(uint256 a) public {
-  //   b = a;
-  // }
-
-  function getB() public view returns (uint256) {
-    return b;
   }
 
   function setState (
@@ -99,6 +88,14 @@ contract TwoPartyDirectChannel {
   }
 
   function startExitFromDeposit() public {
+    require(
+      hasDeposited[0] && hasDeposited[1],
+      "`startExitFromDeposit` should only be called after both deposits are done"
+    );
+    require(
+      msg.sender == participants[0] || msg.sender == participants[1],
+      "Non-participants are banned from calling this `startExitFromDeposit`"
+    );
     if (finalizesAt == 0) {
       finalizesAt = block.number + finalizePeriod;
     }

--- a/virtual_channels/contracts/TwoPartyDirectChannel.sol
+++ b/virtual_channels/contracts/TwoPartyDirectChannel.sol
@@ -21,11 +21,22 @@ contract TwoPartyDirectChannel {
   bool[2] hasDeposited;
   uint256 finalizePeriod;
 
+  uint256 b;
+
   constructor (
     address payable[2] memory _participants, uint256 _finalizePeriod
   ) public {
     participants = _participants;
     finalizePeriod = _finalizePeriod;
+    b = 1;
+  }
+
+  // function testState(uint256 a) public {
+  //   b = a;
+  // }
+
+  function getB() public view returns (uint256) {
+    return b;
   }
 
   function setState (

--- a/virtual_channels/contracts/TwoPartyDirectChannel.sol
+++ b/virtual_channels/contracts/TwoPartyDirectChannel.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 pragma experimental "ABIEncoderV2";
 
 contract TwoPartyDirectChannel {


### PR DESCRIPTION
Fixes https://github.com/paddys-pals/virtual-channels/issues/5.

### TODO
- [x] `startExitFromDeposit`
- [x] `setState`
- [x] `finalize`

### Concerns
- Inline the parameters whose type is either `struct State` or `struct Signature`. This makes it easier to test with `web3.py`. However, should be changed in the future.
- Should clean up the tests and refactor a little bit, including removing test-oriented changes to the contract.